### PR TITLE
Typo on script name

### DIFF
--- a/windows_archive/archive-teslacam-clips
+++ b/windows_archive/archive-teslacam-clips
@@ -84,7 +84,7 @@ function move_clips_to_archive () {
   if [ -r "/root/.teslaCamPushoverCredentials" ]
   then
     log "Sending Pushover message for copied files."
-    /root/bin/send-pushover.sh $move_count
+    /root/bin/send-pushover $move_count
   fi
   log "Finished moving clips to archive."
 }


### PR DESCRIPTION
I had originally named it as `.sh` and was working in my dev copy. Fixed for master now. 