### PR TITLE
Made sed command portable, added checks to not dupe file edits.

### DIFF
--- a/mac_linux_archive/setup-piForHeadlessConfig.sh
+++ b/mac_linux_archive/setup-piForHeadlessConfig.sh
@@ -51,12 +51,22 @@ verify_wifi_variables
 CMDLINE_TXT_PATH="$BOOT_DIR/cmdline.txt"
 CONFIG_TXT_PATH="$BOOT_DIR/config.txt"
 
-echo "Updating $CONFIG_TXT_PATH ..."
-echo "" >> "$CONFIG_TXT_PATH"
-echo "dtoverlay=dwc2" >> "$CONFIG_TXT_PATH"
+if ! grep -q "dtoverlay=dwc2" $CONFIG_TXT_PATH
+then
+   echo "Updating $CONFIG_TXT_PATH ..."
+   echo "" >> "$CONFIG_TXT_PATH"
+   echo "dtoverlay=dwc2" >> "$CONFIG_TXT_PATH"
+else
+   echo "$CONFIG_TXT_PATH already contains the required dwc2 module"
+fi
 
-echo "Updating $CMDLINE_TXT_PATH ..."
-sed -i -e "s/rootwait/rootwait modules-load=dwc2,g_ether/" -e "s@ init=/usr/lib/raspi-config/init_resize.sh@@" "$CMDLINE_TXT_PATH"
+if ! grep -q "dwc2,g_ether" $CMDLINE_TXT_PATH
+then
+  echo "Updating $CMDLINE_TXT_PATH ..."
+  sed -i'.bak' -e "s/rootwait/rootwait modules-load=dwc2,g_ether/" -e "s@ init=/usr/lib/raspi-config/init_resize.sh@@" "$CMDLINE_TXT_PATH"
+else
+  echo "$CMDLINE_TXT_PATH already updated with modules and removed initial resize script."
+fi
 
 echo "Enabling SSH ..."
 touch "$BOOT_DIR/ssh"


### PR DESCRIPTION
See #40 

sed should be portable now, tested on Mac, Raspbian Pi. Added checks to ensure the config/cmdline files aren't updated more than once if the script is re-run. 