### PR TITLE
use BACKINGFILES_MOUNTPOINT in all places for consistency

### DIFF
--- a/run/send-pushover
+++ b/run/send-pushover
@@ -7,7 +7,7 @@ function log () {
   echo "$1" >> "$LOG_FILE"
 }
 
-if [ -r "/root/.teslaCamPushoverCredentials" ] && [ $NUM_FILES_MOVED > 0]
+if [ -r "/root/.teslaCamPushoverCredentials" ] && [ $NUM_FILES_MOVED > 0 ]
 then
   log "Sending Pushover message for moved files."
 

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -27,7 +27,7 @@ function create_teslacam_directory () {
   umount /mnt/cam
 }
 
-FREE_1K_BLOCKS="$(df --output=avail --block-size=1K /backingfiles/ | tail -n 1)"
+FREE_1K_BLOCKS="$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)"
 
 CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 100 ))"
 CAM_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/cam_disk.bin"

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -35,7 +35,7 @@ add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
 
 if [ "$CAM_PERCENT" -lt 100 ]
 then
-  MUSIC_DISK_SIZE="$(df --output=avail --block-size=1K /backingfiles/ | tail -n 1)"
+  MUSIC_DISK_SIZE="$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)"
   MUSIC_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/music_disk.bin"
   add_drive "music" "MUSIC" "$MUSIC_DISK_SIZE" "$MUSIC_DISK_FILE_NAME"
   echo "options g_mass_storage file=$CAM_DISK_FILE_NAME,$MUSIC_DISK_FILE_NAME removable=1,1 ro=0,0 stall=0 iSerialNumber=123456" > "$G_MASS_STORAGE_CONF_FILE_NAME"

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -95,14 +95,14 @@ function create_usb_drive_backing_files () {
     /tmp/create-backingfiles-partition.sh "$BACKINGFILES_MOUNTPOINT"
   fi
   
-  if ! findmnt --mountpoint /backingfiles
+  if ! findmnt --mountpoint $BACKINGFILES_MOUNTPOINT
   then
     echo "Mounting the partition for the backing files..."
-    mount /backingfiles
+    mount $BACKINGFILES_MOUNTPOINT
     echo "Mounted the partition for the backing files."
   fi
 
-  if [ ! -e /backingfiles/*.bin ]
+  if [ ! -e $BACKINGFILES_MOUNTPOINT/*.bin ]
   then
     /tmp/create-backingfiles.sh "$campercent" "$BACKINGFILES_MOUNTPOINT"
   fi


### PR DESCRIPTION
Changing these to instances to a variable will allow someone to change the mount point cleanly. 