### PR TITLE
Rsync Tested and Working

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Whichever instructions you followed above will leave you in a command shell on t
 ### Set up the archive for dashcam clips
 Follow the instructions corresponding to the technology you'd like to use to host the archive for your dashcam clips. You must choose just one of these technoloies; don't follow more than one of these sets of instructions:
 * Windows file share, MacOS Sharing, or Samba on Linux: [Instructions](doc/SetupShare.md).
-* SFTP/rsync: [Instructions](doc/SetupRsync.md)
+* SFTP/rsync: [Instructions](doc/pi/SetupRSync.md)
 * **Experimental:** Google Drive, Amazon S3, DropBox, Microsoft OneDrive: [Instructions](doc/SetupRClone.md)
 
 ### Set up the USB storage functionality

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Whichever instructions you followed above will leave you in a command shell on t
 ### Set up the archive for dashcam clips
 Follow the instructions corresponding to the technology you'd like to use to host the archive for your dashcam clips. You must choose just one of these technoloies; don't follow more than one of these sets of instructions:
 * Windows file share, MacOS Sharing, or Samba on Linux: [Instructions](doc/SetupShare.md).
-* SFTP/rsync: [Instructions](doc/pi/SetupRSync.md)
+* SFTP/rsync: [Instructions](doc/SetupRSync.md)
 * **Experimental:** Google Drive, Amazon S3, DropBox, Microsoft OneDrive: [Instructions](doc/SetupRClone.md)
 
 ### Set up the USB storage functionality

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -159,7 +159,7 @@ function wait_for_archive_to_be_unreachable () {
   log "Waiting for archive to be unreachable..."
   while [ true ]
     do
-      if ! archive_is_reachable
+      if ! retry archive_is_reachable
       then
         log "Archive is unreachable."
         break

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Archiving through rsync..."
 
 source /root/.teslaCamRsyncConfig
 
-num_files_moved=$(rsync -auvh --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* $user@$server:$path | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auzvh --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* $user@$server:$path | awk '/files transferred/{print $NF}')
 
 /root/bin/send-pushover "$num_files_moved"
 

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Archiving through rsync..."
 
 source /root/.teslaCamRsyncConfig
 
-num_files_moved=$(rsync -auzvh --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* $user@$server:$path | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auzvh --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* $user@$server:$path | awk '/files transferred/{print $NF}')
 
 /root/bin/send-pushover "$num_files_moved"
 


### PR DESCRIPTION
A few things lost to the great merge of '18:
*  Adding the compression flag (-z) to the rsync command
*  Retrying the disconnect, which will add a little delay before it will check the file for a forced loop

Other than that I ran into an interesting bug where it was failing to copy because of some permission issues, even though it's set up exactly the same, so I just make rsync ignore preserving permissions, and copy as-is. This is tested and working for me.