### PR TITLE
switch to using hping3 for connectivity testing/ip resolution

### DIFF
--- a/pi-gen-sources/00-packages
+++ b/pi-gen-sources/00-packages
@@ -1,1 +1,2 @@
 dos2unix
+hping3

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -26,7 +26,7 @@ function fix_errors_in_mounted_files () {
 
 function archive_is_reachable () {
   local reachable=true
-  ping -q -w 1 -c 1 "$ARCHIVE_HOST_NAME" > /dev/null 2>&1 || reachable=false
+  hping3 -c 1 -S -p 445 "$ARCHIVE_HOST_NAME" > /dev/null 2>&1 || reachable=false
   if [ "$reachable" = false ]
   then
     false

--- a/run/cifs_archive/verify-archive-configuration.sh
+++ b/run/cifs_archive/verify-archive-configuration.sh
@@ -3,7 +3,7 @@
 function check_archive_server_reachable () {
   echo "Verifying that the archive server $archiveserver is reachable..."
   local serverunreachable=false
-  ping -c 1 -w 1 "$archiveserver" 1>/dev/null 2>&1 || serverunreachable=true
+  hping3 -c 1 -S -p 445 "$archiveserver" 1>/dev/null 2>&1 || serverunreachable=true
 
   if [ "$serverunreachable" = true ]
   then

--- a/run/lookup-ip-address.sh
+++ b/run/lookup-ip-address.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -eu
 
-echo "$(ping -c 1 -w 1 $1 2>/dev/null | head -n 1 | grep -o -e "(\([[:digit:]]\{1,3\}\.\)\{3\}[[:digit:]]\{1,3\})" | tr -d '()')"
+echo "$(hping3 -c 1 -S -p 445 -n $1 2>/dev/null | head -n 1 | grep -o -e "\W\([[:digit:]]\{1,3\}\.\)\{3\}[[:digit:]]\{1,3\})" | tr -d ' )')"

--- a/setup/pi/make-root-fs-readonly.sh
+++ b/setup/pi/make-root-fs-readonly.sh
@@ -7,14 +7,6 @@ function append_cmdline_txt_param() {
   sed -i "s/\'/ ${toAppend}/g" /boot/cmdline.txt >/dev/null
 }
 
-echo "Updating package index files..."
-apt-get update
-echo "Removing unwanted packages..."
-apt-get remove -y --force-yes --purge triggerhappy logrotate dphys-swapfile
-apt-get -y --force-yes autoremove --purge
-# Replace log management with busybox (use logread if needed)
-echo "Installing ntp and busybox-syslogd..."
-apt-get -y --force-yes install ntp busybox-syslogd; dpkg --purge rsyslog
 echo "Configuring system..."
   
 # Add fastboot, noswap and/or ro to end of /boot/cmdline.txt

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -191,8 +191,21 @@ function make_root_fs_readonly () {
   /tmp/make-root-fs-readonly.sh
 }
 
+function install_required_packages () {
+  echo "Updating package index files..."
+  apt-get update
+  echo "Removing unwanted packages..."
+  apt-get remove -y --force-yes --purge triggerhappy logrotate dphys-swapfile
+  apt-get -y --force-yes autoremove --purge
+  # Replace log management with busybox (use logread if needed)
+  echo "Installing ntp, and busybox-syslogd..."
+  apt-get -y --force-yes install ntp busybox-syslogd hping3; dpkg --purge rsyslog
+}
+
 export -f setup_progress
 export HEADLESS_SETUP
+
+install_required_packages
 
 headless_setup_populate_variables
 


### PR DESCRIPTION
This change uses hping3 to test for connectivity to the file server before attempting a mount.
hping3 uses a TCP SYN to attempt to connect to port 445 -- which is what SMB listens on.

Tested with a windows 10 file share, a freenas SMB share, and an azure file share.
