### PR TITLE
make "sudo -i" more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Follow the instructions corresponding to the OS you used to flash the OS onto th
 
 Whichever instructions you followed above will leave you in a command shell on the Pi. Use this shell for the rest of the steps in these instructions.
 
+### Become root on the Pi 
+
+First you need to get into a root shell on the Pi:
+```
+sudo -i
+```
+
+You'll stay in this root shell until you run the "halt" command in the "Set up USB storage functionality" below.  
+
 ### Set up the archive for dashcam clips
 Follow the instructions corresponding to the technology you'd like to use to host the archive for your dashcam clips. You must choose just one of these technologies; don't follow more than one of these sets of instructions:
 * Windows file share, MacOS Sharing, or Samba on Linux: [Instructions](doc/SetupShare.md).

--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -33,6 +33,10 @@ These instructions will speed you through the process with good defaults. If you
 
 # Detailed instructions
 ## Step 1: Install rclone4pi
+1. Enter a root session on your Pi (if you haven't already):
+   ```
+   sudo -i
+   ```
 2. Run the following command to install rclone4pi:
     ```
     curl -L https://raw.github.com/pageauc/rclone4pi/master/rclone-install.sh | bash

--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -11,7 +11,7 @@ You must perform these steps **after** getting a shell on the Pi and **before** 
 # Quick guide
 These instructions will speed you through the process with good defaults. If you encounter an error, or you want to use a different config name than `gdrive` or a different folder name than `TeslaCam`, follow the detailed instuctions, below.  
 
-1. Enter the root session if you haven't already
+1. Enter the root session if you haven't already:
    ```
    sudo -i
    ```

--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -13,7 +13,6 @@ These instructions will speed you through the process with good defaults. If you
 
 1. Run these commands. Specify the config name `gdrive` when prompted for the config name.
    ```
-   sudo -i
    curl -L https://raw.github.com/pageauc/rclone4pi/master/rclone-install.sh | bash
    rclone config
    ```
@@ -26,14 +25,10 @@ These instructions will speed you through the process with good defaults. If you
    rclone mkdir "$RCLONE_DRIVE:$RCLONE_PATH"
    rclone lsd "$RCLONE_DRIVE":
    ```
-1. If you didn't encounter any error messages and you see the `TeslaCam` directory listed return to the [Main Instructions](../README.md).
+1. If you didn't encounter any error messages and you see the `TeslaCam` directory listed, stay in your `sudo -i session` and return to the [Main Instructions](../README.md).
 
 # Detailed instructions
 ## Step 1: Install rclone4pi
-1. Run this command to enter a command shell for the root user.
-    ```
-    sudo -i
-    ```
 2. Run the following command to install rclone4pi:
     ```
     curl -L https://raw.github.com/pageauc/rclone4pi/master/rclone-install.sh | bash
@@ -88,4 +83,4 @@ Run this command to cause the setup processes which you'll resume in the main in
 ```
 export ARCHIVE_SYSTEM=rclone
 ```
-Now return to the section "Set up the USB storage functionality" in the [main instructions](../README.md).
+Now stay in your `sudo -i` session and return to the section "Set up the USB storage functionality" in the [main instructions](../README.md).

--- a/doc/SetupRClone.md
+++ b/doc/SetupRClone.md
@@ -9,8 +9,12 @@ You must perform these steps **after** getting a shell on the Pi and **before** 
 * These commands define environment variables that the main setup scripts need.
 
 # Quick guide
-These instructions will speed you through the process with good defaults. If you encounter an error, or you want to use a different config name than `gdrive` or a different folder name than `TeslaCam`, follow the detailed instuctions, below.
+These instructions will speed you through the process with good defaults. If you encounter an error, or you want to use a different config name than `gdrive` or a different folder name than `TeslaCam`, follow the detailed instuctions, below.  
 
+1. Enter the root session if you haven't already
+   ```
+   sudo -i
+   ```
 1. Run these commands. Specify the config name `gdrive` when prompted for the config name.
    ```
    curl -L https://raw.github.com/pageauc/rclone4pi/master/rclone-install.sh | bash
@@ -25,7 +29,7 @@ These instructions will speed you through the process with good defaults. If you
    rclone mkdir "$RCLONE_DRIVE:$RCLONE_PATH"
    rclone lsd "$RCLONE_DRIVE":
    ```
-1. If you didn't encounter any error messages and you see the `TeslaCam` directory listed, stay in your `sudo -i session` and return to the [Main Instructions](../README.md).
+1. If you didn't encounter any error messages and you see the `TeslaCam` directory listed, stay in your `sudo -i` session  and return to the [Main Instructions](../README.md).
 
 # Detailed instructions
 ## Step 1: Install rclone4pi

--- a/doc/SetupRSync.md
+++ b/doc/SetupRSync.md
@@ -12,6 +12,11 @@ This guide makes the following assumptions:
 # Step 1: Authentication
 Similar to sftp, rsync by default uses ssh to connect to a remote server and transfer files. This guide will use a generated ssh keypair, hence the first assumption above.
 
+1. Enter the root session (if you haven't already):
+   ```
+   sudo -i
+   ```
+
 1. Run these commands to to generate an ssh key for the `root` user:
    ```
    ssh-keygen

--- a/doc/SetupRSync.md
+++ b/doc/SetupRSync.md
@@ -14,7 +14,6 @@ Similar to sftp, rsync by default uses ssh to connect to a remote server and tra
 
 1. Run these commands to to generate an ssh key for the `root` user:
    ```
-   sudo -i
    ssh-keygen
    ```
 

--- a/doc/SetupRSync.md
+++ b/doc/SetupRSync.md
@@ -47,4 +47,4 @@ export RSYNC_USER=pi
 export RSYNC_SERVER=192.168.1.254
 export RSYNC_PATH=/mnt/PIHDD/TeslaCam/
 ```
-Now return to the section "Set up the USB storage functionality" in the [main instructions](../README.md).
+Stay in the `sudo -i` session return to the section "Set up the USB storage functionality" in the [main instructions](../README.md).

--- a/doc/SetupShare.md
+++ b/doc/SetupShare.md
@@ -22,7 +22,6 @@ Now, on the Pi:
 
 1. Run these commands, subsituting your values:
     ```
-    sudo -i
     export ARCHIVE_SYSTEM="cifs"
     export archiveserver="Nautilus"
     export sharename="SailfishCam"

--- a/doc/SetupShare.md
+++ b/doc/SetupShare.md
@@ -4,6 +4,10 @@ Set up a share to host the archive on a computer on your home network. These ins
 It is recommended that you create a new user. Grant the user you'll be using read/write access to the share. These instructions will assume that the user you've created is named "sailfish" and that the password for this user is "pa$$w0rd".
 
 Now, on the Pi:
+1. Enter the root session (if you haven't already):
+   ```
+   sudo -i
+   ```
 1. Try to ping your archive server from the Pi. In this example the server is named `nautilus`.
     ```
     ping -c 3 nautilus
@@ -29,4 +33,4 @@ Now, on the Pi:
     export sharepassword="pa$$w0rd"
     ```
 
-Now return to the section "Set up the USB storage functionality" in the [main instructions](/README.md).
+Now stay in your `sudo -i` session and return to the section "Set up the USB storage functionality" in the [main instructions](/README.md).


### PR DESCRIPTION
This attempts to make it clear that you need to stay in the root sudo -i session until it's time to halt the Pi at the end of the "Set up USB storage functionality" step.  