### PR TITLE
Test of using BTRFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.vscode
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/opt/python/libexec/bin/python"
+}

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -282,7 +282,6 @@ mount_and_fix_errors_in_files
 connect_usb_drives_to_host
 
 log "Removing any existing snapshot of /backingfiles..."
-unmount_cam_snap_file
 if [ -d /backingfiles/snap ]
 then
   btrfs subv delete -c /backingfiles/snap

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -3,9 +3,10 @@ ARCHIVE_HOST_NAME="$1"
 
 export LOG_FILE=/mutable/archiveloop.log
 
-export CAM_MOUNT=/backingfiles/camsnap
+export CAM_MOUNT=/mnt/cam
 export MUSIC_MOUNT=/mnt/music
 export ARCHIVE_MOUNT=/mnt/archive
+export CAM_SNAP_MOUNT=/mnt/cam_snap
 
 function log () {
   echo "$( date )" >> "$LOG_FILE"
@@ -132,6 +133,12 @@ function ensure_cam_file_is_mounted () {
   log "Ensured cam file is mounted."
 }
 
+function ensure_cam_snap_file_is_mounted () {
+  log "Ensuring cam snap file is mounted..."
+  ensure_mountpoint_is_mounted_with_retry "$CAM_SNAP_MOUNT"
+  log "Ensured cam snap file is mounted."
+}
+
 function ensure_music_file_is_mounted () {
   log "Ensuring music backing file is mounted..."
   ensure_mountpoint_is_mounted_with_retry "$MUSIC_MOUNT"
@@ -147,6 +154,10 @@ function unmount_mount_point () {
 
 function unmount_cam_file () {
   unmount_mount_point "$CAM_MOUNT"
+}
+
+function unmount_cam_snap_file () {
+  unmount_mount_point "$CAM_SNAP_MOUNT"
 }
 
 function unmount_music_file () {
@@ -207,19 +218,34 @@ function archive_teslacam_clips () {
 
   /root/bin/connect-archive.sh
 
+  #RG# Since we fix the files on script start, and use snapshot, don't disconnect
   #disconnect_usb_drives_from_host
 
+  #RG# take readonly snapshot to read from
+  log "Taking read-only snapshot of /backingfiles to /backingfiles/snap.."
+  btrfs subv snapshot -r /backingfiles /backingfiles/snap
+  
+  #RG# mount the snapshot instead
   #ensure_cam_file_is_mounted
+  ensure_cam_snap_file_is_mounted
 
+  #RG#
+  # errors should be fixed on script start;
+  # I don't think we should worry about scenarios where there's a constant
+  # cycling between archive available and not 
   #fix_errors_in_cam_file
 
   /root/bin/archive-clips.sh
 
   /root/bin/disconnect-archive.sh
 
-  unmount_cam_file
+  #RG# Unmount the snapshot file instead
+  #unmount_cam_file
+  unmount_cam_snap_file
+  log "Removing snapshot of /backingfiles..."
+  btrfs subv delete /backingfiles/snap
 
-  connect_usb_drives_to_host
+  #connect_usb_drives_to_host
 }
 
 function archive_clips () {
@@ -251,18 +277,28 @@ export -f log
 
 log "Starting..."
 
+#RG# always fix on boot/start, to take logic out of messing with it later
+mount_and_fix_errors_in_files
+connect_usb_drives_to_host
+
+
 if archive_is_reachable
 then
   # archive_clips will fix errors in the cam file
-  mount_and_fix_errors_in_music_file
+  #RG# files should be fixed at boot
+  #mount_and_fix_errors_in_music_file
 
   archive_clips
 
   wait_for_archive_to_be_unreachable
 else
-  mount_and_fix_errors_in_files
-
-  connect_usb_drives_to_host
+  #RG#
+  #mount_and_fix_errors_in_files
+  
+  log "Archive isn't reachable, starting wait loop"
+  
+  #RG# never disconnected 
+  #connect_usb_drives_to_host
 fi
 
 while [ true ]

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -3,7 +3,7 @@ ARCHIVE_HOST_NAME="$1"
 
 export LOG_FILE=/mutable/archiveloop.log
 
-export CAM_MOUNT=/mnt/cam
+export CAM_MOUNT=/backingfiles/camsnap
 export MUSIC_MOUNT=/mnt/music
 export ARCHIVE_MOUNT=/mnt/archive
 
@@ -207,11 +207,11 @@ function archive_teslacam_clips () {
 
   /root/bin/connect-archive.sh
 
-  disconnect_usb_drives_from_host
+  #disconnect_usb_drives_from_host
 
-  ensure_cam_file_is_mounted
+  #ensure_cam_file_is_mounted
 
-  fix_errors_in_cam_file
+  #fix_errors_in_cam_file
 
   /root/bin/archive-clips.sh
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -243,7 +243,7 @@ function archive_teslacam_clips () {
   #unmount_cam_file
   unmount_cam_snap_file
   log "Removing snapshot of /backingfiles..."
-  btrfs subv delete /backingfiles/snap
+  btrfs subv delete -c /backingfiles/snap
 
   #connect_usb_drives_to_host
 }
@@ -281,6 +281,12 @@ log "Starting..."
 mount_and_fix_errors_in_files
 connect_usb_drives_to_host
 
+log "Removing any existing snapshot of /backingfiles..."
+unmount_cam_snap_file
+if [ -d /backingfiles/snap ]
+then
+  btrfs subv delete -c /backingfiles/snap
+fi
 
 if archive_is_reachable
 then

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -4,18 +4,43 @@ log "Moving clips to archive..."
 
 NUM_FILES_MOVED=0
 
+function copy_file () {
+
+ if cp -f -t "$ARCHIVE_MOUNT" -- "$file_name" >> "$LOG_FILE" 2>&1
+      then
+        log "Copied $file_name."
+        NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
+      else
+        log "Failed to move $file_name."
+      fi
+
+}
+
 for file_name in "$CAM_SNAP_MOUNT"/TeslaCam/saved*; do
   [ -e "$file_name" ] || continue
-  log "Moving $file_name ..."
-  
-  if cp -f -t "$ARCHIVE_MOUNT" -- "$file_name" >> "$LOG_FILE" 2>&1
-  then
-    log "Moved $file_name."
-    NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
+  log "Copying $file_name ..."
+  # Get base file name without path 
+  TARGET_FILE_NAME=$(echo $file_name | cut -d'/' -f5)
+
+  # If the file exists in the archive already...
+  if [ -e "${ARCHIVE_MOUNT}/${TARGET_FILE_NAME}" ]
+  then 
+    # Get source and target file sizes (faster than hash or rsync)
+    SOURCE_FILE_SIZE=$(stat --printf="%s" "${file_name}")
+    TARGET_FILE_SIZE=$(stat --printf="%s" "${ARCHIVE_MOUNT}/${TARGET_FILE_NAME}")
+    
+    # If they are not the same size then copy
+    if [ $SOURCE_FILE_SIZE -ne $TARGET_FILE_SIZE ]
+    then
+     copy_file
+    else
+      log "File $file_name alrea"
+    fi
   else
-    log "Failed to move $file_name."
+    # The file didn't exist in the target so just copy away
+    copy_file
   fi
-  
+
 done
 log "Moved $NUM_FILES_MOVED file(s)."
 

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -34,7 +34,7 @@ for file_name in "$CAM_SNAP_MOUNT"/TeslaCam/saved*; do
     then
      copy_file
     else
-      log "File $file_name alrea"
+      log "File $file_name already exists, not copying."
     fi
   else
     # The file didn't exist in the target so just copy away

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -4,11 +4,11 @@ log "Moving clips to archive..."
 
 NUM_FILES_MOVED=0
 
-for file_name in "$CAM_MOUNT"/TeslaCam/saved*; do
+for file_name in "$CAM_SNAP_MOUNT"/TeslaCam/saved*; do
   [ -e "$file_name" ] || continue
   log "Moving $file_name ..."
   
-  if mv -f -t "$ARCHIVE_MOUNT" -- "$file_name" >> "$LOG_FILE" 2>&1
+  if cp -f -t "$ARCHIVE_MOUNT" -- "$file_name" >> "$LOG_FILE" 2>&1
   then
     log "Moved $file_name."
     NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))

--- a/setup/pi/clean.sh
+++ b/setup/pi/clean.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+reset=`tput sgr0`
+
+function bad_msg () {
+    msg=$1
+    echo "${red}${1}${reset}"
+}
+
+function good_msg () {
+    msg=$1
+    echo "${green}${1}${reset}"
+}
+
+bad_msg "This will attempt to reset the changes setup-teslausb made to your Pi."
+echo "This can be destructive and should be used with care!"
+echo "Press Ctrl-C to exit now if you don't want to continue."
+read -p "Press any other key to start..."
+
+if [ -e /root/bin/remountfs_rw ]
+then
+    /root/bin/remountfs_rw 
+fi
+
+umount /backingfiles
+umount /mutable
+rm -rf /mnt/cam
+parted -s -m /dev/mmcblk0 rm 3 
+parted -s -m /dev/mmcblk0 rm 4 
+rm /tmp/*.sh

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -12,27 +12,23 @@ function setup_progress () {
 
 BACKINGFILES_MOUNTPOINT="$1"
 MUTABLE_MOUNTPOINT="$2"
+# BACKINGFILES_MOUNTPOINT="/backingfiles"
+# MUTABLE_MOUNTPOINT="/mutable"
 
 setup_progress "Checking existing partitions..."
-PARTITION_TABLE=$(parted -m /dev/mmcblk0 unit B print)
-DISK_LINE=$(echo "$PARTITION_TABLE" | grep -e "^/dev/mmcblk0:")
-DISK_SIZE=$(echo "$DISK_LINE" | cut -d ":" -f 2 | sed 's/B//' )
+export DISK_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0)"
+export BOOT_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p1)"
+export ROOT_PARTITION_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p2)"
+export USED_PERCENTAGE="$(( ($BOOT_SIZE_BYTES+$ROOT_PARTITION_SIZE_BYTES) * 100 / $DISK_SIZE_BYTES ))"
+export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
 
-ROOT_PARTITION_LINE=$(echo "$PARTITION_TABLE" | grep -e "^2:")
-LAST_ROOT_PARTITION_BYTE=$(echo "$ROOT_PARTITION_LINE" | sed 's/B//g' | cut -d ":" -f 3)
-
-FIRST_BACKINGFILES_PARTITION_BYTE="$(( $LAST_ROOT_PARTITION_BYTE + 1 ))"
-LAST_BACKINGFILES_PARTITION_DESIRED_BYTE="$(( $DISK_SIZE - (100 * (2 ** 20)) - 1))"
+# Per the googles, percentages will align optimal, within an acceptable margin
+setup_progress "Modifying partition table for backing files partition..."
+parted  -s -m /dev/mmcblk0 mkpart primary ext4 $NEW_START_PERCENTAGE% 85%
+setup_progress "Modifying partition table for mutable partition..."
+parted  -s -m /dev/mmcblk0 mkpart primary ext4 86% 100% 
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
-
-setup_progress "Modifying partition table for backing files partition..."
-BACKINGFILES_PARTITION_END_SPEC="$(( $LAST_BACKINGFILES_PARTITION_DESIRED_BYTE / 1000000 ))M"
-parted -a optimal -m /dev/mmcblk0 unit B mkpart primary ext4 "$FIRST_BACKINGFILES_PARTITION_BYTE" "$BACKINGFILES_PARTITION_END_SPEC"
-
-setup_progress "Modifying partition table for mutable (writable) partition for script usage..."
-MUTABLE_PARTITION_START_SPEC="$BACKINGFILES_PARTITION_END_SPEC"
-parted  -a optimal -m /dev/mmcblk0 unit B mkpart primary ext4 "$MUTABLE_PARTITION_START_SPEC" 100%
 
 NEW_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 
@@ -41,8 +37,8 @@ sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/g" /etc/fstab
 sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/" /boot/cmdline.txt
 
 setup_progress "Formatting new partitions..."
-mkfs.ext4 -F /dev/mmcblk0p3
-mkfs.ext4 -F /dev/mmcblk0p4
+mkfs.btrfs -L backingfiles /dev/mmcblk0p3
+mkfs.btrfs -L mutable /dev/mmcblk0p4
 
-echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT ext4 auto,rw,noatime 0 2" >> /etc/fstab
-echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT ext4 auto,rw 0 2" >> /etc/fstab
+echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
+echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -24,9 +24,9 @@ export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
 
 # Per the googles, percentages will align optimal, within an acceptable margin
 setup_progress "Modifying partition table for backing files partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary btrfs $NEW_START_PERCENTAGE% 85%
+parted  -s -m /dev/mmcblk0 mkpart btrfs $NEW_START_PERCENTAGE% 85%
 setup_progress "Modifying partition table for mutable partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary btrfs 86% 100% 
+parted  -s -m /dev/mmcblk0 mkpart primary 86% 100% 
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 
@@ -37,8 +37,8 @@ sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/g" /etc/fstab
 sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/" /boot/cmdline.txt
 
 setup_progress "Formatting new partitions..."
-mkfs.btrfs -L backingfiles /dev/mmcblk0p3
-mkfs.btrfs -L mutable /dev/mmcblk0p4
+mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
+mkfs.btrfs -f -L mutable /dev/mmcblk0p4
 
 echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
 echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -40,5 +40,6 @@ setup_progress "Formatting new partitions..."
 mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
 mkfs.btrfs -f -L mutable /dev/mmcblk0p4
 
+cp /etc/fstab /etc/fstab.orig
 echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
 echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -41,5 +41,7 @@ mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
 mkfs.btrfs -f -L mutable /dev/mmcblk0p4
 
 cp /etc/fstab /etc/fstab.orig
-echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
-echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab
+echo "LABEL=backingfiles /backingfiles btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+echo "LABEL=mutable /mutable btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+# echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
+# echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -24,9 +24,9 @@ export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
 
 # Per the googles, percentages will align optimal, within an acceptable margin
 setup_progress "Modifying partition table for backing files partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary ext4 $NEW_START_PERCENTAGE% 85%
+parted  -s -m /dev/mmcblk0 mkpart primary btrfs $NEW_START_PERCENTAGE% 85%
 setup_progress "Modifying partition table for mutable partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary ext4 86% 100% 
+parted  -s -m /dev/mmcblk0 mkpart primary btrfs 86% 100% 
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -24,9 +24,9 @@ export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
 
 # Per the googles, percentages will align optimal, within an acceptable margin
 setup_progress "Modifying partition table for backing files partition..."
-parted  -s -m /dev/mmcblk0 mkpart btrfs $NEW_START_PERCENTAGE% 85%
+parted  -s -m /dev/mmcblk0 mkpart primary btrfs $NEW_START_PERCENTAGE% 85%
 setup_progress "Modifying partition table for mutable partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary 86% 100% 
+parted  -s -m /dev/mmcblk0 mkpart primary btrfs 86% 100% 
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -1,34 +1,28 @@
 #!/bin/bash -eu
 
-function setup_progress () {
-  local setup_logfile=/boot/teslausb-headless-setup.log
-  local headless_setup=${HEADLESS_SETUP:-false}
-  if [ $headless_setup = "true" ]
-  then
-    echo "$( date ) : $1" >> "$setup_logfile"
-  fi
-    echo $1
-}
-
 BACKINGFILES_MOUNTPOINT="$1"
 MUTABLE_MOUNTPOINT="$2"
-# BACKINGFILES_MOUNTPOINT="/backingfiles"
-# MUTABLE_MOUNTPOINT="/mutable"
 
 setup_progress "Checking existing partitions..."
-export DISK_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0)"
-export BOOT_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p1)"
-export ROOT_PARTITION_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p2)"
-export USED_PERCENTAGE="$(( ($BOOT_SIZE_BYTES+$ROOT_PARTITION_SIZE_BYTES) * 100 / $DISK_SIZE_BYTES ))"
-export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
+PARTITION_TABLE=$(parted -m /dev/mmcblk0 unit B print)
+DISK_LINE=$(echo "$PARTITION_TABLE" | grep -e "^/dev/mmcblk0:")
+DISK_SIZE=$(echo "$DISK_LINE" | cut -d ":" -f 2 | sed 's/B//' )
 
-# Per the googles, percentages will align optimal, within an acceptable margin
-setup_progress "Modifying partition table for backing files partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary btrfs $NEW_START_PERCENTAGE% 85%
-setup_progress "Modifying partition table for mutable partition..."
-parted  -s -m /dev/mmcblk0 mkpart primary btrfs 86% 100% 
+ROOT_PARTITION_LINE=$(echo "$PARTITION_TABLE" | grep -e "^2:")
+LAST_ROOT_PARTITION_BYTE=$(echo "$ROOT_PARTITION_LINE" | sed 's/B//g' | cut -d ":" -f 3)
+
+FIRST_BACKINGFILES_PARTITION_BYTE="$(( $LAST_ROOT_PARTITION_BYTE + 1 ))"
+LAST_BACKINGFILES_PARTITION_DESIRED_BYTE="$(( $DISK_SIZE - (100 * (2 ** 20)) - 1))"
 
 ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
+
+setup_progress "Modifying partition table for backing files partition..."
+BACKINGFILES_PARTITION_END_SPEC="$(( $LAST_BACKINGFILES_PARTITION_DESIRED_BYTE / 1000000 ))M"
+parted -a optimal -m /dev/mmcblk0 unit B mkpart primary btrfs "$FIRST_BACKINGFILES_PARTITION_BYTE" "$BACKINGFILES_PARTITION_END_SPEC"
+
+setup_progress "Modifying partition table for mutable (writable) partition for script usage..."
+MUTABLE_PARTITION_START_SPEC="$BACKINGFILES_PARTITION_END_SPEC"
+parted  -a optimal -m /dev/mmcblk0 unit B mkpart primary ext4 "$MUTABLE_PARTITION_START_SPEC" 100%
 
 NEW_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
 
@@ -38,10 +32,53 @@ sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/" /boot/cmdline.txt
 
 setup_progress "Formatting new partitions..."
 mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
-mkfs.btrfs -f -L mutable /dev/mmcblk0p4
+mkfs.ext4 -F /dev/mmcblk0p4
+echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+# echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT ext4 auto,rw,noatime 0 2" >> /etc/fstab
+echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT ext4 auto,rw 0 2" >> /etc/fstab
 
-cp /etc/fstab /etc/fstab.orig
-#echo "LABEL=backingfiles /backingfiles btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
-#echo "LABEL=mutable /mutable btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
-# echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
-# echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab
+# function setup_progress () {
+#   local setup_logfile=/boot/teslausb-headless-setup.log
+#   local headless_setup=${HEADLESS_SETUP:-false}
+#   if [ $headless_setup = "true" ]
+#   then
+#     echo "$( date ) : $1" >> "$setup_logfile"
+#   fi
+#     echo $1
+# }
+
+# BACKINGFILES_MOUNTPOINT="$1"
+# MUTABLE_MOUNTPOINT="$2"
+# # BACKINGFILES_MOUNTPOINT="/backingfiles"
+# # MUTABLE_MOUNTPOINT="/mutable"
+
+# setup_progress "Checking existing partitions..."
+# export DISK_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0)"
+# export BOOT_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p1)"
+# export ROOT_PARTITION_SIZE_BYTES="$(blockdev --getsize64 /dev/mmcblk0p2)"
+# export USED_PERCENTAGE="$(( ($BOOT_SIZE_BYTES+$ROOT_PARTITION_SIZE_BYTES) * 100 / $DISK_SIZE_BYTES ))"
+# export NEW_START_PERCENTAGE="$(( $USED_PERCENTAGE + 1 ))"
+
+# # Per the googles, percentages will align optimal, within an acceptable margin
+# setup_progress "Modifying partition table for backing files partition..."
+# parted  -s -m /dev/mmcblk0 mkpart primary btrfs $NEW_START_PERCENTAGE% 85%
+# setup_progress "Modifying partition table for mutable partition..."
+# parted  -s -m /dev/mmcblk0 mkpart primary btrfs 86% 100% 
+
+# ORIGINAL_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
+
+# NEW_DISK_IDENTIFIER=$( fdisk -l /dev/mmcblk0 | grep -e "^Disk identifier" | sed "s/Disk identifier: 0x//" )
+
+# setup_progress "Writing updated partitions to fstab and /boot/cmdline.txt"
+# sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/g" /etc/fstab
+# sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/" /boot/cmdline.txt
+
+# setup_progress "Formatting new partitions..."
+# mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
+# mkfs.btrfs -f -L mutable /dev/mmcblk0p4
+
+# cp /etc/fstab /etc/fstab.orig
+# #echo "LABEL=backingfiles /backingfiles btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+# #echo "LABEL=mutable /mutable btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+# # echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
+# # echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -41,7 +41,7 @@ mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
 mkfs.btrfs -f -L mutable /dev/mmcblk0p4
 
 cp /etc/fstab /etc/fstab.orig
-echo "LABEL=backingfiles /backingfiles btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
-echo "LABEL=mutable /mutable btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+#echo "LABEL=backingfiles /backingfiles btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+#echo "LABEL=mutable /mutable btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
 # echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs auto,rw,noatime 0 2" >> /etc/fstab
 # echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT btrfs auto,rw 0 2" >> /etc/fstab

--- a/setup/pi/create-backingfiles-partition.sh
+++ b/setup/pi/create-backingfiles-partition.sh
@@ -33,7 +33,7 @@ sed -i "s/${ORIGINAL_DISK_IDENTIFIER}/${NEW_DISK_IDENTIFIER}/" /boot/cmdline.txt
 setup_progress "Formatting new partitions..."
 mkfs.btrfs -f -L backingfiles /dev/mmcblk0p3
 mkfs.ext4 -F /dev/mmcblk0p4
-echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs defaults,ssd_spread,noatime,noauto 0 0" >> /etc/fstab
+echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT btrfs defaults,ssd_spread,noatime 0 0" >> /etc/fstab
 # echo "/dev/mmcblk0p3 $BACKINGFILES_MOUNTPOINT ext4 auto,rw,noatime 0 2" >> /etc/fstab
 echo "/dev/mmcblk0p4 $MUTABLE_MOUNTPOINT ext4 auto,rw 0 2" >> /etc/fstab
 

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -29,7 +29,7 @@ function create_teslacam_directory () {
 
 FREE_1K_BLOCKS="$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)"
 
-CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 100 ))"
+CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 95 ))"
 CAM_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/cam_disk.bin"
 add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
 

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -17,19 +17,19 @@ function add_drive () {
 
   local mountpoint=/mnt/"$name"
 
-  mkdir "$mountpoint"
+  mkdir -p "$mountpoint"
   echo "$filename $mountpoint vfat noauto,users,umask=000 0 0" >> /etc/fstab
 }
 
 function create_teslacam_directory () {
   mount /mnt/cam
-  mkdir /mnt/cam/TeslaCam
+  mkdir -p /mnt/cam/TeslaCam
   umount /mnt/cam
 }
 
 FREE_1K_BLOCKS="$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)"
 
-CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 95 ))"
+CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 100 ))"
 CAM_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/cam_disk.bin"
 add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
 
@@ -42,5 +42,5 @@ then
 else
   echo "options g_mass_storage file=$CAM_DISK_FILE_NAME removable=1 ro=0 stall=0 iSerialNumber=123456" > "$G_MASS_STORAGE_CONF_FILE_NAME"
 fi
-
+mkdir -p /mnt/cam_snap
 create_teslacam_directory

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -42,5 +42,7 @@ then
 else
   echo "options g_mass_storage file=$CAM_DISK_FILE_NAME removable=1 ro=0 stall=0 iSerialNumber=123456" > "$G_MASS_STORAGE_CONF_FILE_NAME"
 fi
+# I know this is messy for now, will functionize later
+echo "/backingfiles/snap/cam_disk.bin /mnt/cam_snap vfat noauto,users,umask=000 0 0" >> /etc/fstab
 mkdir -p /mnt/cam_snap
 create_teslacam_directory

--- a/setup/pi/create-backingfiles.sh
+++ b/setup/pi/create-backingfiles.sh
@@ -29,7 +29,8 @@ function create_teslacam_directory () {
 
 FREE_1K_BLOCKS="$(df --output=avail --block-size=1K $BACKINGFILES_MOUNTPOINT/ | tail -n 1)"
 
-CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 100 ))"
+#RG# Reserve an extra 10 percent for btrfs operations
+CAM_DISK_SIZE="$(( $FREE_1K_BLOCKS * $CAM_PERCENT / 110 ))"
 CAM_DISK_FILE_NAME="$BACKINGFILES_MOUNTPOINT/cam_disk.bin"
 add_drive "cam" "CAM" "$CAM_DISK_SIZE" "$CAM_DISK_FILE_NAME"
 

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -199,12 +199,6 @@ function update_package_index () {
   apt-get install -y btrfs-tools
 }
 
-function update_initramfs() {
-  echo "btrfs" >> /etc/initramfs-tools/modules
-  update-initramfs -c -k `uname -r`
-  echo "initramfs initrd.img-4.14.79+ followkernel" >> /boot/config.txt
-
-}
 
 function upgrade_packages () {
     apt-mark hold raspberrypi-kernel raspberrypi-bootloader
@@ -264,11 +258,7 @@ then
   /root/configure.sh
 fi
 
-#update_initramfs
-
 make_root_fs_readonly
-
-
 
 upgrade_packages
 

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -196,17 +196,17 @@ function make_root_fs_readonly () {
 function update_package_index () {
   setup_progress "Updating package index files..."
   apt-get update
-  apt-mark hold raspberrypi-kernel raspberrypi-bootloader
   apt-get install -y btrfs-tools
 }
 
 function update_initramfs() {
   echo "btrfs" >> /etc/initramfs-tools/modules
   update-initramfs -c -k `uname -r`
-  
+
 }
 
 function upgrade_packages () {
+    apt-mark hold raspberrypi-kernel raspberrypi-bootloader
   if [ "$UPGRADE_PACKAGES" = true ]
   then
     setup_progress "Upgrading installed packages..."
@@ -264,6 +264,8 @@ then
 fi
 
 make_root_fs_readonly
+
+update_initramfs
 
 upgrade_packages
 

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -164,7 +164,7 @@ function create_usb_drive_backing_files () {
     setup_progress "Mounted the partition for the backing files."
   fi
 
-  if [ ! -e $BACKINGFILES_MOUNTPOINT/*.bin ]
+  if [ ! -e $BACKINGFILES_MOUNTPOINT/cam.bin ]
   then
     setup_progress "Creating backing disk files."
     /tmp/create-backingfiles.sh "$campercent" "$BACKINGFILES_MOUNTPOINT"

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -196,6 +196,7 @@ function make_root_fs_readonly () {
 function update_package_index () {
   setup_progress "Updating package index files..."
   apt-get update
+  apt-get install -y btrfs-tools
 }
 
 function upgrade_packages () {

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -202,6 +202,7 @@ function update_package_index () {
 function update_initramfs() {
   echo "btrfs" >> /etc/initramfs-tools/modules
   update-initramfs -c -k `uname -r`
+  echo "initramfs initrd.img-4.14.79+ followkernel" >> /boot/config.txt
 
 }
 
@@ -263,9 +264,11 @@ then
   /root/configure.sh
 fi
 
+#update_initramfs
+
 make_root_fs_readonly
 
-update_initramfs
+
 
 upgrade_packages
 

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -196,7 +196,14 @@ function make_root_fs_readonly () {
 function update_package_index () {
   setup_progress "Updating package index files..."
   apt-get update
+  apt-mark hold raspberrypi-kernel raspberrypi-bootloader
   apt-get install -y btrfs-tools
+}
+
+function update_initramfs() {
+  echo "btrfs" >> /etc/initramfs-tools/modules
+  update-initramfs -c -k `uname -r`
+  
 }
 
 function upgrade_packages () {


### PR DESCRIPTION
Take a look at this @cimryan please.

Changes:
* `backingfiles` is created as btrfs (and tools are installed)
* vfat disks are mounted at the start of the loop instead of in the loop. My thinking is that the normal pattern of the Pi being shut down and restarted with the car is basically a given. So fix them once each "boot". I don't _think_ this should be needed during the archive mount and copy
* snapshot is created/mounted/deleted during archiving, files are copied from there, and drives are never removed from the host. To see how stability is improved/isn't.

Problems:
* Since it's a snapshot, files are **copied** not moved. If we go down this path, we can figure out how to deal with that. Some people want them copied not moved anyway, so a purge algorithm might be better anyway.
* I reverted to using your partitioning logic; parted doesn't seem to be loving the way I was doing it, or I ended up creating a bug. I'll figure this out separately as I like the simpler logic
* I'm missing something basic but `campercent` less than 100 ends up causing the music disk to be created too big. Again probably some basic thing I missed

It's a proof of concept, but I like it, if it tests stably (and better than using a simultaneous `ro` mount which is another option to explore). `btrfs` is used in production pretty heavily so I don't feel too worried about it...yet. 
