### PR TITLE
Support for specifying alternate hostname for Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ For example, using `export campercent=100` would allocate 100% of the space to r
 ### Optional: Configure push notification via Pushover
 If you'd like to receive a text message when your Pi finishes archiving clips follow these [Instructions](doc/ConfigureNotificationsForArchive.md).
 
+### Optional: Configure a hostname
+The default network hostname for the Pi will become `teslausb`.  If you want to have more than one TeslaUSB devices on your network (for example you have more than one Tesla in your houseold), then you can specify an alternate hostname for the Pi by running this command:
+
+```
+ export TESLAUSB_HOSTNAME=<new hostname>
+```
+
+For example, you could use `export TESLAUSB_HOSTNAME=teslausb-ModelX`
+
+Make sure that whatever you speicfy for the new hostname is compliant with the rules for DNS hostnames; for example underscore (_) is not allowed, but dash (-) is allowed.  Full rules are in RFC 1178 at https://tools.ietf.org/html/rfc1178
+
 ### Set up the USB storage functionality
 1. Run these commands:
     ```
@@ -103,7 +114,7 @@ If you'd like to receive a text message when your Pi finishes archiving clips fo
     ```
 1. Disconnect the Pi from the computer.
 
-On the next boot, the Pi hostname will become `teslausb`, so future `ssh` sessions will be `ssh pi@teslausb.local`. 
+On the next boot, the Pi hostname will become `teslausb`, so future `ssh` sessions will be `ssh pi@teslausb.local`.   If you specified your own hostname, be sure to use that name (for example `ssh pi@teslausb-ModelX.local`)
 
 Your Pi is now ready to be plugged into your Tesla. If you want to add music to the Pi, follow the instructions in the next section.
 

--- a/doc/teslausb_setup_variables.conf.sample
+++ b/doc/teslausb_setup_variables.conf.sample
@@ -23,6 +23,9 @@ export WIFIPASS=your_pass
 # If doing a headless (i.e. automatic) setup
 export HEADLESS_SETUP=true
 
+# Uncomment if you want to override the default hostname of "teslausb"
+# export TESLAUSB_HOSTNAME=teslausb-Model3
+
 # Uncomment if setting up Pushover push notifications 
 # export pushover_enabled=false
 # export pushover_user_key=user_key

--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -6,6 +6,7 @@ HEADLESS_SETUP=${HEADLESS_SETUP:-false}
 USE_LED_FOR_SETUP_PROGRESS=true
 CONFIGURE_ARCHIVING=${CONFIGURE_ARCHIVING:-true}
 UPGRADE_PACKAGES=${UPGRADE_PACKAGES:-true}
+TESLAUSB_HOSTNAME=${TESLAUSB_HOSTNAME:-teslausb}
 export campercent=${campercent:-90}
 
 function setup_progress () {
@@ -177,7 +178,7 @@ function configure_hostname () {
   then
     setup_progress "Configuring the hostname..."
 
-    local new_host_name="teslausb"
+    local new_host_name="$TESLAUSB_HOSTNAME"
     cp /etc/hosts ~
     sed "s/raspberrypi/$new_host_name/g" ~/hosts > /etc/hosts
     rm ~/hosts


### PR DESCRIPTION
Adding support for having multiple teslausb instances on the same local network.  This is to cover the case where there are multiple Teslas in the same household and allow disambiguation of the Pi instances by giving them unique hostnames.