### PR TITLE
Update rc.local: fix diagnostic output

### DIFF
--- a/pi-gen-sources/files/rc.local
+++ b/pi-gen-sources/files/rc.local
@@ -144,7 +144,8 @@ then
 else
   echo "Setup doesn't seem to have completed, there is no /root/bin/archiveloop."
   echo "Try re-running /root/bin/setup-teslausb (re-downloading if needed),"
-  echo "or export HEADLESS=true and run /etc/rc.local if you want to run automatic setup."
+  echo "or export HEADLESS_SETUP=true and run /etc/rc.local if you want to run automatic setup."
+  echo "(you may also need to rm /boot/TESLAUSB_SETUP_FINISHED to force setup to re-run)"
 fi
 exit 0
 


### PR DESCRIPTION
One-step headless setup troubleshooting steps say to manually run /etc/rc.local, so it's important that rc.local actually prints correct and complete info.
