### PR TITLE
Fix image creation for Tesla firmware 2019.5.x

### DIFF
--- a/run/archiveloop
+++ b/run/archiveloop
@@ -15,7 +15,9 @@ function log () {
 function fix_errors_in_mount_point () {
   local mount_point="$1"
   log "Running fsck on $mount_point..."
-  /sbin/fsck "$mount_point" -- -a >> "$LOG_FILE" 2>&1 || echo ""
+  local backingfile=$(mount | grep -w '/mnt/cam' | awk '{print $1}') 
+  local loopback=$(losetup -l | grep -w  "$backingfile" | awk '{print $1}')
+  /sbin/fsck "$loopback" -- -a >> "$LOG_FILE" 2>&1 || echo ""
   log "Finished fsck on $mount_point."
 }
 

--- a/run/archiveloop
+++ b/run/archiveloop
@@ -15,7 +15,7 @@ function log () {
 function fix_errors_in_mount_point () {
   local mount_point="$1"
   log "Running fsck on $mount_point..."
-  local backingfile=$(mount | grep -w '/mnt/cam' | awk '{print $1}') 
+  local backingfile=$(mount | grep -w "$mount_point" | awk '{print $1}') 
   local loopback=$(losetup -l | grep -w  "$backingfile" | awk '{print $1}')
   /sbin/fsck "$loopback" -- -a >> "$LOG_FILE" 2>&1 || echo ""
   log "Finished fsck on $mount_point."


### PR DESCRIPTION
As of firmware 2019.5.x, Tesla expects a partitioned device for storing
dashcam recordings. While this is not required for the music drive, this
change modifies both camera and music images to use a partition table
with a single primary partition formatted as FAT32, instead of formatting
the entire device/file..