### PR TITLE
Support firmware 2019.5.x path names

### DIFF
--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Moving clips to archive..."
 
 NUM_FILES_MOVED=0
 
-for file_name in "$CAM_MOUNT"/TeslaCam/saved*; do
+for file_name in "$CAM_MOUNT"/TeslaCam/saved* "$CAM_MOUNT"/TeslaCam/SavedClips/*; do
   [ -e "$file_name" ] || continue
   log "Moving $file_name ..."
   

--- a/run/cifs_archive/archive-clips.sh
+++ b/run/cifs_archive/archive-clips.sh
@@ -4,24 +4,44 @@ log "Moving clips to archive..."
 
 NUM_FILES_MOVED=0
 
-for file_name in "$CAM_MOUNT"/TeslaCam/saved* "$CAM_MOUNT"/TeslaCam/SavedClips/*; do
-  [ -e "$file_name" ] || continue
-  log "Moving $file_name ..."
-  
-  if mv -f -t "$ARCHIVE_MOUNT" -- "$file_name" >> "$LOG_FILE" 2>&1
-  then
-    log "Moved $file_name."
-    NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
-  else
-    log "Failed to move $file_name."
-  fi
-  
-done
+function moveclips() {
+  ROOT="$1"
+  PATTERN="$2"
+
+  while read file_name
+  do
+    if [ -d "$ROOT/$file_name" ]
+    then
+      log "Creating output directory '$file_name'"
+      mkdir -p "$ARCHIVE_MOUNT/$file_name"
+    elif [ -f "$ROOT/$file_name" ]
+    then
+      log "Moving '$file_name'"
+      outdir=$(dirname "$file_name")
+      if mv -f "$ROOT/$file_name" "$ARCHIVE_MOUNT/$outdir"
+      then
+        log "Moved '$file_name'"
+      else
+        log "Failed to move '$file_name'"
+      fi
+      NUM_FILES_MOVED=$((NUM_FILES_MOVED + 1))
+    else
+      log "$file_name not found"
+    fi
+  done <<< $(cd "$ROOT"; find $PATTERN)
+}
+
+# legacy file name pattern, firmware 2018.*
+moveclips "$CAM_MOUNT/TeslaCam" 'saved*'
+
+# new file name pattern, firmware 2019.*
+moveclips "$CAM_MOUNT/TeslaCam/SavedClips" '*'
+
 log "Moved $NUM_FILES_MOVED file(s)."
 
 if [ $NUM_FILES_MOVED -gt 0 ]
 then
-/root/bin/send-pushover "$NUM_FILES_MOVED"
+  /root/bin/send-pushover "$NUM_FILES_MOVED"
 fi
 
 log "Finished moving clips to archive."

--- a/run/rclone_archive/archive-clips.sh
+++ b/run/rclone_archive/archive-clips.sh
@@ -6,7 +6,7 @@ source /root/.teslaCamRcloneConfig
 
 NUM_FILES_MOVED=0
 
-for file_name in "$CAM_MOUNT"/TeslaCam/saved*; do
+for file_name in "$CAM_MOUNT"/TeslaCam/saved* "$CAM_MOUNT"/TeslaCam/SavedClips/*; do
   [ -e "$file_name" ] || continue
   log "Moving $file_name ..."
   rclone --config /root/.config/rclone/rclone.conf move "$file_name" "$drive:$path" >> "$LOG_FILE" 2>&1 || echo ""

--- a/run/rsync_archive/archive-clips.sh
+++ b/run/rsync_archive/archive-clips.sh
@@ -4,7 +4,7 @@ log "Archiving through rsync..."
 
 source /root/.teslaCamRsyncConfig
 
-num_files_moved=$(rsync -auzvh --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* $user@$server:$path | awk '/files transferred/{print $NF}')
+num_files_moved=$(rsync -auzvh --no-perms --stats --log-file=/tmp/archive-rsync-cmd.log /mnt/cam/TeslaCam/saved* /mnt/cam/TeslaCam/SavedClips/* $user@$server:$path | awk '/files transferred/{print $NF}')
 
 /root/bin/send-pushover "$num_files_moved"
 


### PR DESCRIPTION
Firmware 2019.5.x changed the naming pattern of the recording files,
as well as their location. Archive both old and new files.